### PR TITLE
Add AllowPartiallyTrustedCallers

### DIFF
--- a/AgileMapper.PerformanceTester/Properties/AssemblyInfo.cs
+++ b/AgileMapper.PerformanceTester/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security;
 
 [assembly: AssemblyTitle("AgileMapper.PerformanceTester")]
-
+[assembly: AllowPartiallyTrustedCallers]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
AllowPartiallyTrustedCallers skips some security checks in the CLR.
http://stackoverflow.com/questions/5053032/performance-of-compiled-to-delegate-expression/5160513