### PR TITLE
Bugs/unused constructor members

### DIFF
--- a/AgileMapper.UnitTests/WhenMappingToConstructors.cs
+++ b/AgileMapper.UnitTests/WhenMappingToConstructors.cs
@@ -98,6 +98,16 @@
             result.StringValue.ShouldBe("Copy!");
         }
 
+        // See https://github.com/agileobjects/AgileMapper/issues/139
+        [Fact]
+        public void ShouldPopulateMembersMatchingUnusedConstructorParameters()
+        {
+            var source = new { Value1 = 123 };
+            var result = Mapper.Map(source).ToANew<MultipleUnusedConstructors<int, int>>();
+            
+            result.Value1.ShouldBe(123);
+        }
+
         #region Helper Classes
 
         // ReSharper disable ClassNeverInstantiated.Local
@@ -122,6 +132,23 @@
             public T1 Value1 { get; }
 
             public T2 Value2 { get; }
+        }
+
+        private class MultipleUnusedConstructors<T1, T2>
+        {
+            public MultipleUnusedConstructors()
+            {
+            }
+
+            public MultipleUnusedConstructors(T1 value1, T2 value2)
+            {
+                Value1 = value1;
+                Value2 = value2;
+            }
+
+            public T1 Value1 { get; set; }
+
+            public T2 Value2 { get; set; }
         }
 
         private class CopyConstructor

--- a/AgileMapper.UnitTests/WhenValidatingMappings.cs
+++ b/AgileMapper.UnitTests/WhenValidatingMappings.cs
@@ -17,255 +17,369 @@
         [Fact]
         public void ShouldSupportCachedMapperValidation()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.GetPlanFor<PublicProperty<string>>().ToANew<PublicProperty<int>>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.GetPlanFor<PublicProperty<string>>().ToANew<PublicProperty<int>>();
 
-                Should.NotThrow(() => mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
-            }
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
         }
 
         [Fact]
         public void ShouldErrorIfCachedMappingMembersHaveNoDataSources()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper.GetPlanFor(new { Thingy = default(string) }).ToANew<PublicProperty<long>>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.GetPlanFor(new { Thingy = default(string) }).ToANew<PublicProperty<long>>();
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
 
-                validationEx.Message.ShouldContain("AnonymousType<string> -> PublicProperty<long>");
-                validationEx.Message.ShouldContain("Rule set: CreateNew");
-                validationEx.Message.ShouldContain("Unmapped target members");
-                validationEx.Message.ShouldContain("PublicProperty<long>.Value");
-            }
+            validationEx.Message.ShouldContain("AnonymousType<string> -> PublicProperty<long>");
+            validationEx.Message.ShouldContain("Rule set: CreateNew");
+            validationEx.Message.ShouldContain("Unmapped target members");
+            validationEx.Message.ShouldContain("PublicProperty<long>.Value");
         }
 
         [Fact]
         public void ShouldErrorIfCachedNestedMappingMembersHaveNoDataSources()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper
-                    .GetPlanFor(new
+                using (var mapper = Mapper.CreateNew())
+                {
+                    var exampleSource = new
                     {
                         Id = default(string),
                         Title = default(int),
                         Name = default(string)
-                    })
-                    .Over<Person>();
+                    };
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
+                    mapper.GetPlanFor(exampleSource).Over<Person>();
 
-                validationEx.Message.ShouldContain(" -> Person");
-                validationEx.Message.ShouldNotContain(" -> Person.Address");
-                validationEx.Message.ShouldContain("Rule set: Overwrite");
-                validationEx.Message.ShouldContain("Unmapped target members");
-                validationEx.Message.ShouldContain("Person.Address");
-                validationEx.Message.ShouldContain("Person.Address.Line1");
-                validationEx.Message.ShouldContain("Person.Address.Line2");
-            }
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
+
+            validationEx.Message.ShouldContain(" -> Person");
+            validationEx.Message.ShouldNotContain(" -> Person.Address");
+            validationEx.Message.ShouldContain("Rule set: Overwrite");
+            validationEx.Message.ShouldContain("Unmapped target members");
+            validationEx.Message.ShouldContain("Person.Address");
+            validationEx.Message.ShouldContain("Person.Address.Line1");
+            validationEx.Message.ShouldContain("Person.Address.Line2");
         }
 
         [Fact]
         public void ShouldNotErrorIfCachedMappingMemberIsIgnored()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.WhenMapping
-                    .From<PublicProperty<string>>().To<PublicField<int>>()
-                    .Ignore(pf => pf.Value);
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping
+                        .From<PublicProperty<string>>().To<PublicField<int>>()
+                        .Ignore(pf => pf.Value);
 
-                string plan = mapper.GetPlanFor<PublicProperty<string>>().OnTo<PublicField<int>>();
+                    // ReSharper disable once UnusedVariable
+                    string plan = mapper.GetPlanFor<PublicProperty<string>>().OnTo<PublicField<int>>();
 
-                Should.NotThrow(() => mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
-            }
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
         }
 
         [Fact]
         public void ShouldNotErrorIfUnmappedCachedMappingMemberIsIgnored()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.WhenMapping
-                    .From(new { LaLaLa = default(int) }).To<PublicField<int>>()
-                    .Ignore(pf => pf.Value);
+                var exampleSource = new { LaLaLa = default(int) };
 
-                mapper.GetPlanFor(new { LaLaLa = default(int) }).OnTo<PublicField<int>>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping
+                        .From(exampleSource).To<PublicField<int>>()
+                        .Ignore(pf => pf.Value);
 
-                Should.NotThrow(() => mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
-            }
+                    mapper.GetPlanFor(exampleSource).OnTo<PublicField<int>>();
+
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
         }
 
         [Fact]
         public void ShouldErrorIfComplexTypeMemberIsUnconstructable()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper
-                    .GetPlanFor<PublicField<PublicField<int>>>()
-                    .ToANew<PublicProperty<PublicTwoParamCtor<int, int>>>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    var exampleSource = new { Value = new { Value2 = default(int) } };
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
+                    mapper
+                        .GetPlanFor(exampleSource)
+                        .ToANew<PublicProperty<PublicTwoParamCtor<int, int>>>();
 
-                validationEx.Message.ShouldContain("PublicField<PublicField<int>> -> PublicProperty<PublicTwoParamCtor<int, int>>");
-                validationEx.Message.ShouldContain("Unconstructable target Types");
-                validationEx.Message.ShouldContain("PublicField<int> -> PublicTwoParamCtor<int, int>");
-                validationEx.Message.ShouldContain("Unmapped target members");
-                validationEx.Message.ShouldContain("PublicProperty<PublicTwoParamCtor<int, int>>.Value");
-            }
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
+
+            validationEx.Message.ShouldContain("AnonymousType<AnonymousType<int>> -> PublicProperty<PublicTwoParamCtor<int, int>>");
+            validationEx.Message.ShouldContain("Unconstructable target Types");
+            validationEx.Message.ShouldContain("AnonymousType<int> -> PublicTwoParamCtor<int, int>");
+        }
+
+        [Fact]
+        public void ShouldRecogniseConstructableComplexTypeMembersWithNoMappableMembers()
+        {
+            var validationEx = Should.Throw<MappingValidationException>(() =>
+            {
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper
+                        .GetPlanFor<PublicProperty<PublicTwoFieldsStruct<int, int>>>()
+                        .ToANew<PublicField<PublicField<int>>>();
+
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
+
+            validationEx.Message.ShouldContain("PublicProperty<PublicTwoFieldsStruct<int, int>> -> PublicField<PublicField<int>>");
+            validationEx.Message.ShouldNotContain("Unconstructable target Types");
+            validationEx.Message.ShouldNotContain("PublicTwoFieldsStruct<int, int> -> PublicField<int>");
+            validationEx.Message.ShouldContain("Unmapped target members");
+            validationEx.Message.ShouldContain("- PublicField<PublicField<int>>.Value.Value");
         }
 
         [Fact]
         public void ShouldNotErrorIfConstructableComplexTypeMemberHasNoMatchingSource()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.WhenMapping
-                    .From<CustomerViewModel>()
-                    .To<Customer>()
-                    .Ignore(c => c.Title, c => c.Address.Line2);
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping
+                        .From<CustomerViewModel>()
+                        .To<Customer>()
+                        .Ignore(c => c.Title, c => c.Address.Line2);
 
-                mapper.GetPlanFor<CustomerViewModel>().ToANew<Customer>();
+                    mapper.GetPlanFor<CustomerViewModel>().ToANew<Customer>();
 
-                Should.NotThrow(() => mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
-            }
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
+        }
+
+        [Fact]
+        public void ShouldNotErrorIfUnconstructableComplexTypeMemberHasFactoryMethod()
+        {
+            Should.NotThrow(() =>
+            {
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.GetPlanFor<PublicField<string>>().ToANew<UnconstructableFactoryMethod>();
+
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
+        }
+
+        [Fact]
+        public void ShouldNotErrorIfUnconstructableComplexTypeMemberHasConfiguredFactoryMethod()
+        {
+            Should.NotThrow(() =>
+            {
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping
+                        .From<Address>()
+                        .ToANew<PublicCtor<string>>()
+                        .CreateInstancesUsing(ctx => new PublicCtor<string>(ctx.Source.Line1));
+
+                    mapper
+                        .GetPlanFor<PublicField<Address>>()
+                        .ToANew<PublicField<PublicCtor<string>>>();
+
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
         }
 
         [Fact]
         public void ShouldErrorIfEnumerableMemberHasNonEnumerableSource()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper
-                    .GetPlanFor<PublicField<Address>>()
-                    .ToANew<PublicProperty<ICollection<string>>>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper
+                        .GetPlanFor<PublicField<Address>>()
+                        .ToANew<PublicProperty<ICollection<string>>>();
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
 
-                validationEx.Message.ShouldContain("PublicField<Address> -> PublicProperty<ICollection<string>>");
-                validationEx.Message.ShouldContain("Unmapped target members");
-                validationEx.Message.ShouldContain("PublicProperty<ICollection<string>>.Value");
-            }
+            validationEx.Message.ShouldContain("PublicField<Address> -> PublicProperty<ICollection<string>>");
+            validationEx.Message.ShouldContain("Unmapped target members");
+            validationEx.Message.ShouldContain("PublicProperty<ICollection<string>>.Value");
         }
 
         [Fact]
         public void ShouldErrorIfEnumerableMemberHasUnconstructableElements()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper
-                    .GetPlanFor<Address[]>()
-                    .ToANew<PublicCtor<string>[]>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper
+                        .GetPlanFor<Address[]>()
+                        .ToANew<PublicCtor<string>[]>();
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
 
-                validationEx.Message.ShouldContain("Address[] -> PublicCtor<string>[]");
-                validationEx.Message.ShouldContain("Unconstructable target Types");
-                validationEx.Message.ShouldContain("Address -> PublicCtor<string>");
-            }
+            validationEx.Message.ShouldContain("Address[] -> PublicCtor<string>[]");
+            validationEx.Message.ShouldContain("Unconstructable target Types");
+            validationEx.Message.ShouldContain("Address -> PublicCtor<string>");
         }
 
         [Fact]
         public void ShouldShowMultipleIncompleteCachedMappingPlans()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper.GetPlansFor<Person>().To<ProductDto>();
-                mapper.GetPlansFor<Product>().To<PersonViewModel>();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.GetPlansFor<Person>().To<ProductDto>();
+                    mapper.GetPlansFor<Product>().To<PersonViewModel>();
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete());
+                    mapper.ThrowNowIfAnyMappingPlanIsIncomplete();
+                }
+            });
 
-                validationEx.Message.ShouldContain("Person -> ProductDto");
-                validationEx.Message.ShouldNotContain("ProductDto.ProductId"); // <- Because PVM has a PersonId
-                validationEx.Message.ShouldContain("ProductDto.Price");
+            validationEx.Message.ShouldContain("Person -> ProductDto");
+            validationEx.Message.ShouldNotContain("ProductDto.ProductId"); // <- Because PVM has a PersonId
+            validationEx.Message.ShouldContain("ProductDto.Price");
 
-                validationEx.Message.ShouldContain("Product -> PersonViewModel");
-                validationEx.Message.ShouldContain("PersonViewModel.Name");
-                validationEx.Message.ShouldContain("PersonViewModel.AddressLine1");
-            }
+            validationEx.Message.ShouldContain("Product -> PersonViewModel");
+            validationEx.Message.ShouldContain("PersonViewModel.Name");
+            validationEx.Message.ShouldContain("PersonViewModel.AddressLine1");
         }
 
         [Fact]
         public void ShouldValidateMappingPlanMemberMappingByDefault()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper.WhenMapping.ThrowIfAnyMappingPlanIsIncomplete();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping.ThrowIfAnyMappingPlanIsIncomplete();
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.GetPlanFor(new { Head = "Spinning" }).ToANew<PublicField<string>>());
+                    mapper.GetPlanFor(new { Head = "Spinning" }).ToANew<PublicField<string>>();
+                }
+            });
 
-                validationEx.Message.ShouldContain("AnonymousType<string> -> PublicField<string>");
-                validationEx.Message.ShouldContain("Unmapped target members");
-                validationEx.Message.ShouldContain("PublicField<string>.Value");
-            }
+            validationEx.Message.ShouldContain("AnonymousType<string> -> PublicField<string>");
+            validationEx.Message.ShouldContain("Unmapped target members");
+            validationEx.Message.ShouldContain("PublicField<string>.Value");
         }
 
         [Fact]
         public void ShouldNotErrorIfUnmappedMemberHasConfiguredDataSourceWhenValidatingMappingPlansByDefault()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.WhenMapping
-                    .ThrowIfAnyMappingPlanIsIncomplete()
-                    .AndWhenMapping
-                    .From<Product>().To<PublicProperty<Guid>>()
-                    .Map((p, pp) => p.ProductId)
-                    .To(p => p.Value);
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping
+                        .ThrowIfAnyMappingPlanIsIncomplete()
+                        .AndWhenMapping
+                        .From<Product>().To<PublicProperty<Guid>>()
+                        .Map((p, pp) => p.ProductId)
+                        .To(p => p.Value);
 
-                Should.NotThrow(() =>
-                    mapper.GetPlansFor<Product>().To<PublicProperty<Guid>>());
-            }
+                    mapper.GetPlansFor<Product>().To<PublicProperty<Guid>>();
+                }
+            });
         }
 
         [Fact]
         public void ShouldValidateMappingPlanEnumMatchingByDefault()
         {
-            using (var mapper = Mapper.CreateNew())
+            var validationEx = Should.Throw<MappingValidationException>(() =>
             {
-                mapper.WhenMapping.ThrowIfAnyMappingPlanIsIncomplete();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping.ThrowIfAnyMappingPlanIsIncomplete();
 
-                var validationEx = Should.Throw<MappingValidationException>(() =>
-                    mapper.Map(new PublicField<PaymentTypeUk>()).ToANew<PublicField<PaymentTypeUs>>());
+                    mapper.Map(new PublicField<PaymentTypeUk>()).ToANew<PublicField<PaymentTypeUs>>();
+                }
+            });
 
-                validationEx.Message.ShouldContain("PublicField<PaymentTypeUk> -> PublicField<PaymentTypeUs>");
-                validationEx.Message.ShouldContain("Unpaired enum values");
-                validationEx.Message.ShouldContain("PaymentTypeUk.Cheque matches no PaymentTypeUs");
-            }
+            validationEx.Message.ShouldContain("PublicField<PaymentTypeUk> -> PublicField<PaymentTypeUs>");
+            validationEx.Message.ShouldContain("Unpaired enum values");
+            validationEx.Message.ShouldContain("PaymentTypeUk.Cheque matches no PaymentTypeUs");
         }
 
         [Fact]
         public void ShouldNotErrorIfEnumMismatchesAreAllTargetToSource()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.WhenMapping.ThrowIfAnyMappingPlanIsIncomplete();
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping.ThrowIfAnyMappingPlanIsIncomplete();
 
-                Should.NotThrow(() =>
-                    mapper.GetPlanFor<PublicField<PaymentTypeUk>>().ToANew<PublicField<PaymentType>>());
-            }
+                    mapper.GetPlanFor<PublicField<PaymentTypeUk>>().ToANew<PublicField<PaymentType>>();
+                }
+            });
         }
 
         [Fact]
         public void ShouldNotErrorIfEnumValuesArePairedWhenValidatingMappingPlansByDefault()
         {
-            using (var mapper = Mapper.CreateNew())
+            Should.NotThrow(() =>
             {
-                mapper.WhenMapping
-                    .ThrowIfAnyMappingPlanIsIncomplete()
-                    .AndWhenMapping
-                    .PairEnum(PaymentTypeUk.Cheque).With(PaymentTypeUs.Check);
+                using (var mapper = Mapper.CreateNew())
+                {
+                    mapper.WhenMapping
+                        .ThrowIfAnyMappingPlanIsIncomplete()
+                        .AndWhenMapping
+                        .PairEnum(PaymentTypeUk.Cheque).With(PaymentTypeUs.Check);
 
-                Should.NotThrow(() =>
-                    mapper.Map(new PublicField<PaymentTypeUk>()).ToANew<PublicField<PaymentTypeUs>>());
-            }
+                    mapper.Map(new PublicField<PaymentTypeUk>()).ToANew<PublicField<PaymentTypeUs>>();
+                }
+            });
         }
+
+        #region Helper Classes
+
+        private class UnconstructableFactoryMethod
+        {
+            private UnconstructableFactoryMethod(string valueString)
+            {
+                Value = valueString;
+            }
+
+            // ReSharper disable once UnusedMember.Local
+            public static UnconstructableFactoryMethod Create(string value)
+                => new UnconstructableFactoryMethod(value);
+
+            // ReSharper disable once MemberCanBePrivate.Local
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public string Value { get; }
+        }
+
+        #endregion
     }
 }

--- a/AgileMapper/Api/Configuration/CustomDataSourceTargetMemberSpecifier.cs
+++ b/AgileMapper/Api/Configuration/CustomDataSourceTargetMemberSpecifier.cs
@@ -130,9 +130,7 @@
                 return;
             }
 
-            var targetMemberType = (targetMember.LeafMember.MemberType == MemberType.ConstructorParameter)
-                ? "constructor parameter"
-                : "member";
+            var targetMemberType = targetMember.IsConstructorParameter() ? "constructor parameter" : "member";
 
             throw new MappingConfigurationException(string.Format(
                 CultureInfo.InvariantCulture,

--- a/AgileMapper/DataSources/DataSourceSet.cs
+++ b/AgileMapper/DataSources/DataSourceSet.cs
@@ -79,14 +79,21 @@ namespace AgileObjects.AgileMapper.DataSources
 
             for (var i = _dataSources.Count - 1; i >= 0;)
             {
+                var isFirstDataSource = value == default(Expression);
                 var dataSource = _dataSources[i--];
 
-                value = dataSource.AddPreConditionIfNecessary(value == default(Expression)
-                    ? dataSource.Value
-                    : Expression.Condition(
+                var dataSourceValue = dataSource.IsConditional
+                    ? Expression.Condition(
                         dataSource.Condition,
-                        dataSource.Value.GetConversionTo(value.Type),
-                        value));
+                        isFirstDataSource 
+                            ? dataSource.Value
+                            : dataSource.Value.GetConversionTo(value.Type),
+                        isFirstDataSource
+                            ? dataSource.Value.Type.ToDefaultExpression()
+                            : value)
+                    : dataSource.Value;
+
+                value = dataSource.AddPreConditionIfNecessary(dataSourceValue);
             }
 
             return value;

--- a/AgileMapper/MappingDataExtensions.cs
+++ b/AgileMapper/MappingDataExtensions.cs
@@ -17,7 +17,7 @@
                 .MapperData
                 .MapperContext
                 .ConstructionFactory
-                .GetNewObjectCreationInfos(mappingData)
+                .GetTargetObjectCreationInfos(mappingData)
                 .Any();
         }
 

--- a/AgileMapper/MappingDataExtensions.cs
+++ b/AgileMapper/MappingDataExtensions.cs
@@ -1,10 +1,6 @@
 ﻿namespace AgileObjects.AgileMapper
 {
-#if NET35
-    using Microsoft.Scripting.Ast;
-#else
-    using System.Linq.Expressions;
-#endif
+    using System.Linq;
     using DataSources;
     using Extensions.Internal;
     using Members;
@@ -16,7 +12,14 @@
             => mappingData.IsRoot || mappingData.MappingTypes.RuntimeTypesNeeded;
 
         public static bool IsTargetConstructable(this IObjectMappingData mappingData)
-            => mappingData.GetTargetObjectCreation() != null;
+        {
+            return mappingData
+                .MapperData
+                .MapperContext
+                .ConstructionFactory
+                .GetNewObjectCreationInfos(mappingData)
+                .Any();
+        }
 
         public static bool IsConstructableFromToTargetDataSource(this IObjectMappingData mappingData)
             => mappingData.GetToTargetDataSourceOrNullForTargetType() != null;
@@ -46,15 +49,6 @@
 
             // TODO: Cover: Unconstructable ToTarget data source
             return null;
-        }
-
-        public static Expression GetTargetObjectCreation(this IObjectMappingData mappingData)
-        {
-            return mappingData
-                .MapperData
-                .MapperContext
-                .ConstructionFactory
-                .GetNewObjectCreation(mappingData);
         }
 
         public static bool HasSameTypedConfiguredDataSource(this IObjectMappingData mappingData)

--- a/AgileMapper/MappingDataExtensions.cs
+++ b/AgileMapper/MappingDataExtensions.cs
@@ -1,10 +1,11 @@
 ﻿namespace AgileObjects.AgileMapper
 {
-    using System.Linq;
+    using System.Collections.Generic;
     using DataSources;
     using Extensions.Internal;
     using Members;
     using ObjectPopulation;
+    using ObjectPopulation.ComplexTypes;
 
     internal static class MappingDataExtensions
     {
@@ -12,13 +13,15 @@
             => mappingData.IsRoot || mappingData.MappingTypes.RuntimeTypesNeeded;
 
         public static bool IsTargetConstructable(this IObjectMappingData mappingData)
+            => GetTargetObjectCreationInfos(mappingData).Any();
+
+        public static IList<IBasicConstructionInfo> GetTargetObjectCreationInfos(this IObjectMappingData mappingData)
         {
             return mappingData
                 .MapperData
                 .MapperContext
                 .ConstructionFactory
-                .GetTargetObjectCreationInfos(mappingData)
-                .Any();
+                .GetTargetObjectCreationInfos(mappingData);
         }
 
         public static bool IsConstructableFromToTargetDataSource(this IObjectMappingData mappingData)

--- a/AgileMapper/Members/Dictionaries/DictionaryTargetMember.cs
+++ b/AgileMapper/Members/Dictionaries/DictionaryTargetMember.cs
@@ -362,7 +362,7 @@ namespace AgileObjects.AgileMapper.Members.Dictionaries
             // entry and we're mapping from a source of type object, we switch from
             // mapping to flattened entries to mapping entire objects:
             return HasObjectEntries &&
-                   LeafMember.IsEnumerableElement() &&
+                   this.IsEnumerableElement() &&
                   (MemberChain[Depth - 2] == _rootDictionaryMember.LeafMember) &&
                   (sourceType == typeof(object));
         }

--- a/AgileMapper/Members/MemberExtensions.cs
+++ b/AgileMapper/Members/MemberExtensions.cs
@@ -149,7 +149,14 @@
         }
 
         [DebuggerStepThrough]
+        public static bool IsEnumerableElement(this QualifiedMember member) => member.LeafMember.IsEnumerableElement();
+
+        [DebuggerStepThrough]
         public static bool IsEnumerableElement(this Member member) => member.MemberType == MemberType.EnumerableElement;
+
+        [DebuggerStepThrough]
+        public static bool IsConstructorParameter(this QualifiedMember member)
+            => member.LeafMember.MemberType == MemberType.ConstructorParameter;
 
         public static IList<string> ExtendWith(
             this ICollection<string> parentJoinedNames,

--- a/AgileMapper/Members/MemberMapperDataExtensions.cs
+++ b/AgileMapper/Members/MemberMapperDataExtensions.cs
@@ -187,31 +187,6 @@ namespace AgileObjects.AgileMapper.Members
             mapperData.Parent.DataSourcesByTargetMember.Add(mapperData.TargetMember, dataSources);
         }
 
-        public static bool TargetMemberIsUnmappable(this IMemberMapperData mapperData, out string reason)
-        {
-            if (!mapperData.RuleSet.Settings.AllowSetMethods &&
-                (mapperData.TargetMember.LeafMember.MemberType == MemberType.SetMethod))
-            {
-                reason = "Set methods are unsupported by rule set '" + mapperData.RuleSet.Name + "'";
-                return true;
-            }
-
-            if (mapperData.TargetMember.LeafMember.HasMatchingCtorParameter &&
-              ((mapperData.Parent?.IsRoot != true) ||
-               !mapperData.RuleSet.Settings.RootHasPopulatedTarget))
-            {
-                reason = "Expected to be populated by constructor parameter";
-                return true;
-            }
-
-            return TargetMemberIsUnmappable(
-                mapperData,
-                mapperData.TargetMember,
-                md => md.MapperContext.UserConfigurations.QueryDataSourceFactories(md),
-                mapperData.MapperContext.UserConfigurations,
-                out reason);
-        }
-
         public static bool TargetMemberIsUnmappable<TTMapperData>(
             this TTMapperData mapperData,
             QualifiedMember targetMember,

--- a/AgileMapper/Members/MemberMapperDataExtensions.cs
+++ b/AgileMapper/Members/MemberMapperDataExtensions.cs
@@ -225,7 +225,7 @@ namespace AgileObjects.AgileMapper.Members
 
         [DebuggerStepThrough]
         public static bool TargetMemberIsEnumerableElement(this IBasicMapperData mapperData)
-            => mapperData.TargetMember.LeafMember.IsEnumerableElement();
+            => mapperData.TargetMember.IsEnumerableElement();
 
         [DebuggerStepThrough]
         public static bool TargetMemberHasInitAccessibleValue(this IMemberMapperData mapperData)

--- a/AgileMapper/Members/Population/MemberPopulationFactoryBase.cs
+++ b/AgileMapper/Members/Population/MemberPopulationFactoryBase.cs
@@ -1,12 +1,12 @@
 namespace AgileObjects.AgileMapper.Members.Population
 {
     using System.Collections.Generic;
-    using Extensions.Internal;
 #if NET35
     using Microsoft.Scripting.Ast;
 #else
     using System.Linq.Expressions;
 #endif
+    using Extensions.Internal;
 
     internal abstract class MemberPopulationFactoryBase : IMemberPopulationFactory
     {

--- a/AgileMapper/Members/Population/MemberPopulatorFactory.cs
+++ b/AgileMapper/Members/Population/MemberPopulatorFactory.cs
@@ -1,18 +1,18 @@
-namespace AgileObjects.AgileMapper.Members.Population
+  namespace AgileObjects.AgileMapper.Members.Population
 {
     using System;
     using System.Collections.Generic;
+#if NET35
+    using Microsoft.Scripting.Ast;
+#else
+    using System.Linq.Expressions;
+#endif
     using Configuration;
     using DataSources.Finders;
     using Extensions;
     using Extensions.Internal;
     using Members;
     using ObjectPopulation;
-#if NET35
-    using Microsoft.Scripting.Ast;
-#else
-    using System.Linq.Expressions;
-#endif
 
     internal class MemberPopulatorFactory
     {
@@ -42,7 +42,7 @@ namespace AgileObjects.AgileMapper.Members.Population
                     {
                         return memberPopulation;
                     }
-
+                    
                     return null;
                 })
                 .WhereNotNull();
@@ -109,9 +109,10 @@ namespace AgileObjects.AgileMapper.Members.Population
                 return false;
             }
 
+            var creationInfos = mappingData.GetTargetObjectCreationInfos();
 
-
-            return true;
+            return creationInfos.Any() &&
+                   creationInfos.All(ci => ci.IsUnconditional && ci.HasCtorParameterFor(mapperData.TargetMember.LeafMember));
         }
 
         private static bool TargetMemberIsUnconditionallyIgnored(

--- a/AgileMapper/Members/Population/MemberPopulatorFactory.cs
+++ b/AgileMapper/Members/Population/MemberPopulatorFactory.cs
@@ -52,7 +52,7 @@ namespace AgileObjects.AgileMapper.Members.Population
         {
             var childMapperData = new ChildMemberMapperData(targetMember, mappingData.MapperData);
 
-            if (childMapperData.TargetMemberIsUnmappable(out var reason))
+            if (TargetMemberIsUnmappable(childMapperData, mappingData, out var reason))
             {
                 return MemberPopulator.Unmappable(childMapperData, reason);
             }
@@ -74,6 +74,44 @@ namespace AgileObjects.AgileMapper.Members.Population
             }
 
             return MemberPopulator.WithRegistration(childMappingData, dataSources, populateCondition);
+        }
+
+        private static bool TargetMemberIsUnmappable(
+            IMemberMapperData mapperData,
+            IObjectMappingData mappingData,
+            out string reason)
+        {
+            if (!mapperData.RuleSet.Settings.AllowSetMethods &&
+                (mapperData.TargetMember.LeafMember.MemberType == MemberType.SetMethod))
+            {
+                reason = "Set methods are unsupported by rule set '" + mapperData.RuleSet.Name + "'";
+                return true;
+            }
+
+            if (TargetMemberWillBePopulatedByCtor(mapperData, mappingData))
+            {
+                reason = "Expected to be populated by constructor parameter";
+                return true;
+            }
+
+            return mapperData.TargetMemberIsUnmappable(
+                mapperData.TargetMember,
+                md => md.MapperContext.UserConfigurations.QueryDataSourceFactories(md),
+                mapperData.MapperContext.UserConfigurations,
+                out reason);
+        }
+
+        private static bool TargetMemberWillBePopulatedByCtor(IMemberMapperData mapperData, IObjectMappingData mappingData)
+        {
+            if (!mapperData.TargetMember.LeafMember.HasMatchingCtorParameter ||
+                (mapperData.RuleSet.Settings.RootHasPopulatedTarget && (mapperData.Parent?.IsRoot == true)))
+            {
+                return false;
+            }
+
+
+
+            return true;
         }
 
         private static bool TargetMemberIsUnconditionallyIgnored(

--- a/AgileMapper/Members/QualifiedMember.cs
+++ b/AgileMapper/Members/QualifiedMember.cs
@@ -83,10 +83,7 @@ namespace AgileObjects.AgileMapper.Members
                 _childMemberCache = mapperContext.Cache.CreateNew<Member, QualifiedMember>(default(HashCodeComparer<Member>));
             }
 
-            RegistrationName = (LeafMember.MemberType != MemberType.ConstructorParameter)
-                ? Name
-                : "ctor:" + Name;
-
+            RegistrationName = this.IsConstructorParameter() ? "ctor:" + Name : Name;
             IsReadOnly = IsReadable && !leafMember.IsWriteable;
         }
 

--- a/AgileMapper/ObjectPopulation/ComplexTypes/ComplexTypeConstructionFactory.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/ComplexTypeConstructionFactory.cs
@@ -31,14 +31,14 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             _constructionsCache = mapperScopedCacheSet.CreateScoped<ConstructionKey, Construction>();
         }
 
-        public IEnumerable<IBasicConstructionInfo> GetNewObjectCreationInfos(IObjectMappingData mappingData)
+        public IEnumerable<IBasicConstructionInfo> GetTargetObjectCreationInfos(IObjectMappingData mappingData)
 #if NET35
-            => GetNewObjectCreationInfos(mappingData, out _).Cast<IBasicConstructionInfo>();
+            => GetTargetObjectCreationInfos(mappingData, out _).Cast<IBasicConstructionInfo>();
 #else
-            => GetNewObjectCreationInfos(mappingData, out _);
+            => GetTargetObjectCreationInfos(mappingData, out _);
 #endif
 
-        private IList<IConstructionInfo> GetNewObjectCreationInfos(
+        private IList<IConstructionInfo> GetTargetObjectCreationInfos(
             IObjectMappingData mappingData, 
             out ConstructionKey constructionKey)
         {
@@ -191,9 +191,9 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 .ToArray();
         }
 
-        public Expression GetNewObjectCreation(IObjectMappingData mappingData)
+        public Expression GetTargetObjectCreation(IObjectMappingData mappingData)
         {
-            var cachedInfos = GetNewObjectCreationInfos(mappingData, out var constructionKey);
+            var cachedInfos = GetTargetObjectCreationInfos(mappingData, out var constructionKey);
 
             if (cachedInfos.None())
             {
@@ -268,17 +268,6 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 #endif
             #endregion
             public override int GetHashCode() => 0;
-        }
-
-        public interface IBasicConstructionInfo
-        {
-            bool IsConfigured { get; }
-            
-            bool IsUnconditional { get; }
-            
-            int ParameterCount { get; }
-            
-            int Priority { get; }
         }
 
         private interface IConstructionInfo : IBasicConstructionInfo, IComparable<IConstructionInfo>

--- a/AgileMapper/ObjectPopulation/ComplexTypes/ComplexTypeConstructionFactory.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/ComplexTypeConstructionFactory.cs
@@ -31,8 +31,12 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             _constructionsCache = mapperScopedCacheSet.CreateScoped<ConstructionKey, Construction>();
         }
 
-        public IList<IBasicConstructionInfo> GetNewObjectCreationInfos(IObjectMappingData mappingData)
-            => (IList<IBasicConstructionInfo>)GetNewObjectCreationInfos(mappingData, out _);
+        public IEnumerable<IBasicConstructionInfo> GetNewObjectCreationInfos(IObjectMappingData mappingData)
+#if NET35
+            => GetNewObjectCreationInfos(mappingData, out _).Cast<IBasicConstructionInfo>();
+#else
+            => GetNewObjectCreationInfos(mappingData, out _);
+#endif
 
         private IList<IConstructionInfo> GetNewObjectCreationInfos(
             IObjectMappingData mappingData, 
@@ -52,6 +56,7 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                     AddAutoConstructionInfos(constructionInfos, key);
                 }
 
+                key.AddSourceMemberTypeTesterIfRequired();
                 key.MappingData = null;
 
                 return constructionInfos.None()

--- a/AgileMapper/ObjectPopulation/ComplexTypes/ComplexTypeConstructionFactory.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/ComplexTypeConstructionFactory.cs
@@ -22,73 +22,50 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 
     internal class ComplexTypeConstructionFactory
     {
-        private readonly ICache<ConstructionKey, Construction> _constructorsCache;
+        private readonly ICache<ConstructionKey, IList<IConstructionInfo>> _constructionInfosCache;
+        private readonly ICache<ConstructionKey, Construction> _constructionsCache;
 
         public ComplexTypeConstructionFactory(CacheSet mapperScopedCacheSet)
         {
-            _constructorsCache = mapperScopedCacheSet.CreateScoped<ConstructionKey, Construction>();
+            _constructionInfosCache = mapperScopedCacheSet.CreateScoped<ConstructionKey, IList<IConstructionInfo>>();
+            _constructionsCache = mapperScopedCacheSet.CreateScoped<ConstructionKey, Construction>();
         }
 
-        public Expression GetNewObjectCreation(IObjectMappingData mappingData)
-        {
-            var objectCreation = _constructorsCache.GetOrAdd(new ConstructionKey(mappingData), key =>
-            {
-                var constructions = new List<Construction>();
+        public IList<IBasicConstructionInfo> GetNewObjectCreationInfos(IObjectMappingData mappingData)
+            => (IList<IBasicConstructionInfo>)GetNewObjectCreationInfos(mappingData, out _);
 
-                AddConfiguredConstructions(
-                    constructions,
+        private IList<IConstructionInfo> GetNewObjectCreationInfos(
+            IObjectMappingData mappingData, 
+            out ConstructionKey constructionKey)
+        {
+            return _constructionInfosCache.GetOrAdd(constructionKey = new ConstructionKey(mappingData), key =>
+            {
+                IList<IConstructionInfo> constructionInfos = new List<IConstructionInfo>();
+
+                AddConfiguredConstructionInfos(
+                    constructionInfos,
                     key,
                     out var otherConstructionRequired);
 
                 if (otherConstructionRequired && !key.MappingData.MapperData.TargetType.IsAbstract())
                 {
-                    AddAutoConstructions(constructions, key);
+                    AddAutoConstructionInfos(constructionInfos, key);
                 }
 
-                if (constructions.None())
-                {
-                    key.MappingData = null;
-                    return null;
-                }
-
-                var construction = Construction.For(constructions, key);
-
-                key.AddSourceMemberTypeTesterIfRequired();
                 key.MappingData = null;
 
-                return construction;
+                return constructionInfos.None()
+                    ? Enumerable<IConstructionInfo>.EmptyArray
+                    : constructionInfos;
             });
-
-            if (objectCreation == null)
-            {
-                return null;
-            }
-
-            mappingData.MapperData.Context.UsesMappingDataObjectAsParameter = objectCreation.UsesMappingDataObjectParameter;
-
-            var creationExpression = objectCreation.GetConstruction(mappingData);
-
-            return creationExpression;
         }
 
-        public Expression GetFactoryMethodObjectCreationOrNull(IObjectMappingData mappingData)
-        {
-            var key = new ConstructionKey(mappingData);
-            var factoryData = GetGreediestAvailableFactories(key);
-
-            return factoryData.Any()
-                ? factoryData.First().Construction.With(key).GetConstruction(mappingData)
-                : null;
-        }
-
-        private static void AddConfiguredConstructions(
-            ICollection<Construction> constructions,
+        private static void AddConfiguredConstructionInfos(
+            ICollection<IConstructionInfo> constructionInfos,
             ConstructionKey key,
             out bool otherConstructionRequired)
         {
             var mapperData = key.MappingData.MapperData;
-
-            otherConstructionRequired = true;
 
             var configuredFactories = mapperData
                 .MapperContext
@@ -97,52 +74,58 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 
             foreach (var configuredFactory in configuredFactories)
             {
-                var configuredConstruction = new Construction(configuredFactory, mapperData);
+                var configuredConstructionInfo = new ConfiguredFactoryInfo(configuredFactory, mapperData);
 
-                constructions.Add(configuredConstruction);
+                constructionInfos.Add(configuredConstructionInfo);
 
-                if (configuredConstruction.IsUnconditional)
+                if (configuredConstructionInfo.IsUnconditional)
                 {
                     otherConstructionRequired = false;
                     return;
                 }
             }
+
+            otherConstructionRequired = true;
         }
 
-        private static void AddAutoConstructions(IList<Construction> constructions, ConstructionKey key)
+        private static void AddAutoConstructionInfos(IList<IConstructionInfo> constructionInfos, ConstructionKey key)
         {
             var mapperData = key.MappingData.MapperData;
 
-            var greediestAvailableFactories = GetGreediestAvailableFactories(key);
-            var greediestUnconditionalFactory = greediestAvailableFactories.LastOrDefault(f => f.IsUnconditional);
+            var greediestAvailableFactoryInfos = GetGreediestAvailableFactoryInfos(key);
+            var greediestUnconditionalFactoryInfo = greediestAvailableFactoryInfos.LastOrDefault(f => f.IsUnconditional);
 
             var constructors = mapperData.TargetInstance.Type
                 .GetPublicInstanceConstructors()
                 .ToArray();
 
-            var greediestAvailableNewings = constructors.Any()
-                ? GetGreediestAvailableNewings(constructors, key, greediestUnconditionalFactory)
-                : Enumerable<ConstructionData<ConstructorInfo>>.EmptyArray;
-
             int i;
 
-            for (i = 0; i < greediestAvailableFactories.Length; i++)
+            for (i = 0; i < greediestAvailableFactoryInfos.Length;)
             {
-                greediestAvailableFactories[i].AddTo(constructions, key);
+                greediestAvailableFactoryInfos[i++].AddTo(constructionInfos, key);
             }
 
-            for (i = 0; i < greediestAvailableNewings.Length; i++)
+            if (constructors.Any())
             {
-                greediestAvailableNewings[i].AddTo(constructions, key);
+                var greediestAvailableNewingInfos = GetGreediestAvailableNewingInfos(
+                    constructors,
+                    key,
+                    greediestUnconditionalFactoryInfo);
+
+                for (i = 0; i < greediestAvailableNewingInfos.Length;)
+                {
+                    greediestAvailableNewingInfos[i++].AddTo(constructionInfos, key);
+                }
             }
 
-            if (constructions.None() && mapperData.TargetMemberIsUserStruct())
+            if (constructionInfos.None() && mapperData.TargetMemberIsUserStruct())
             {
-                constructions.Add(Construction.NewStruct(mapperData.TargetInstance.Type));
+                constructionInfos.Add(new StructInfo(mapperData.TargetInstance.Type));
             }
         }
 
-        private static ConstructionData<MethodInfo>[] GetGreediestAvailableFactories(ConstructionKey key)
+        private static ConstructionDataInfo<MethodInfo>[] GetGreediestAvailableFactoryInfos(ConstructionKey key)
         {
             var mapperData = key.MappingData.MapperData;
 
@@ -150,9 +133,9 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 .GetPublicStaticMethods()
                 .Filter(m => IsFactoryMethod(m, mapperData.TargetInstance.Type));
 
-            return CreateConstructionData(
+            return CreateConstructionInfo(
                 candidateFactoryMethods,
-                fm => new ConstructionData<MethodInfo>(fm, Expression.Call, key, priority: 1));
+                fm => new ConstructionDataInfo<MethodInfo>(fm, Expression.Call, key, priority: 1));
         }
 
         private static bool IsFactoryMethod(MethodInfo method, Type targetType)
@@ -161,20 +144,20 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                    (method.Name.StartsWith("Create", Ordinal) || method.Name.StartsWith("Get", Ordinal));
         }
 
-        private static ConstructionData<ConstructorInfo>[] GetGreediestAvailableNewings(
+        private static ConstructionDataInfo<ConstructorInfo>[] GetGreediestAvailableNewingInfos(
             IEnumerable<ConstructorInfo> constructors,
             ConstructionKey key,
-            ConstructionData<MethodInfo> greediestUnconditionalFactory)
+            IBasicConstructionInfo greediestUnconditionalFactoryInfo)
         {
             var candidateConstructors = constructors
-                .Filter(ctor => IsCandidateCtor(ctor, greediestUnconditionalFactory));
+                .Filter(ctor => IsCandidateCtor(ctor, greediestUnconditionalFactoryInfo));
 
-            return CreateConstructionData(
+            return CreateConstructionInfo(
                 candidateConstructors,
-                ctor => new ConstructionData<ConstructorInfo>(ctor, Expression.New, key, priority: 0));
+                ctor => new ConstructionDataInfo<ConstructorInfo>(ctor, Expression.New, key, priority: 0));
         }
 
-        private static bool IsCandidateCtor(MethodBase ctor, ConstructionData<MethodInfo> candidateFactoryMethod)
+        private static bool IsCandidateCtor(MethodBase ctor, IBasicConstructionInfo candidateFactoryMethod)
         {
             var ctorCarameters = ctor.GetParameters();
 
@@ -190,9 +173,9 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             return ctorParameters.None(p => p.ParameterType == type);
         }
 
-        private static ConstructionData<T>[] CreateConstructionData<T>(
+        private static ConstructionDataInfo<T>[] CreateConstructionInfo<T>(
             IEnumerable<T> invokables,
-            Func<T, ConstructionData<T>> dataFactory)
+            Func<T, ConstructionDataInfo<T>> dataFactory)
             where T : MethodBase
         {
             return invokables
@@ -203,7 +186,47 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 .ToArray();
         }
 
-        public void Reset() => _constructorsCache.Empty();
+        public Expression GetNewObjectCreation(IObjectMappingData mappingData)
+        {
+            var cachedInfos = GetNewObjectCreationInfos(mappingData, out var constructionKey);
+
+            if (cachedInfos.None())
+            {
+                return null;
+            }
+
+            constructionKey.MappingData = mappingData;
+            constructionKey.Infos = cachedInfos;
+
+            var cachedConstruction = _constructionsCache.GetOrAdd(constructionKey, key =>
+            {
+                var constructions = key.Infos.ProjectToArray(info => info.ToConstruction());
+                var construction = Construction.For(constructions, key);
+
+                key.AddSourceMemberTypeTesterIfRequired();
+                key.MappingData = null;
+
+                return construction;
+            });
+
+            mappingData.MapperData.Context.UsesMappingDataObjectAsParameter = cachedConstruction.UsesMappingDataObjectParameter;
+
+            var constructionExpression = cachedConstruction.GetConstruction(mappingData);
+
+            return constructionExpression;
+        }
+
+        public Expression GetFactoryMethodObjectCreationOrNull(IObjectMappingData mappingData)
+        {
+            var key = new ConstructionKey(mappingData);
+            var factoryData = GetGreediestAvailableFactoryInfos(key);
+
+            return factoryData.Any()
+                ? factoryData.First().ToConstruction().With(key).GetConstruction(mappingData)
+                : null;
+        }
+
+        public void Reset() => _constructionsCache.Empty();
 
         #region Helper Classes
 
@@ -220,6 +243,8 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 _sourceMember = mappingData.MapperData.SourceMember;
                 _targetMember = mappingData.MapperData.TargetMember;
             }
+
+            public IList<IConstructionInfo> Infos { get; set; }
 
             public override bool Equals(object obj)
             {
@@ -240,21 +265,98 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             public override int GetHashCode() => 0;
         }
 
-        private class ConstructionData<TInvokable> : IConstructionInfo
+        public interface IBasicConstructionInfo
+        {
+            bool IsConfigured { get; }
+            
+            bool IsUnconditional { get; }
+            
+            int ParameterCount { get; }
+            
+            int Priority { get; }
+        }
+
+        private interface IConstructionInfo : IBasicConstructionInfo, IComparable<IConstructionInfo>
+        {
+            Construction ToConstruction();
+        }
+
+        private abstract class ConstructionInfoBase : IConstructionInfo
+        {
+            public bool IsConfigured { get; protected set; }
+
+            public bool IsUnconditional { get; protected set; }
+
+            public int ParameterCount { get; protected set; }
+
+            public int Priority { get; protected set; }
+
+            public abstract Construction ToConstruction();
+
+            public int CompareTo(IConstructionInfo other)
+            {
+                // ReSharper disable once ImpureMethodCallOnReadonlyValueField
+                var isConfiguredComparison = other.IsConfigured.CompareTo(IsConfigured);
+
+                if (isConfiguredComparison != 0)
+                {
+                    return isConfiguredComparison;
+                }
+
+                var conditionalComparison = IsUnconditional.CompareTo(other.IsUnconditional);
+
+                if (conditionalComparison != 0)
+                {
+                    return conditionalComparison;
+                }
+
+                var paramCountComparison = ParameterCount.CompareTo(other.ParameterCount);
+
+                if (paramCountComparison != 0)
+                {
+                    return paramCountComparison;
+                }
+
+                var priorityComparison = other.Priority.CompareTo(Priority);
+
+                return priorityComparison;
+            }
+        }
+
+        private sealed class ConfiguredFactoryInfo : ConstructionInfoBase
+        {
+            private readonly ConfiguredObjectFactory _configuredFactory;
+            private readonly IMemberMapperData _mapperData;
+
+            public ConfiguredFactoryInfo(ConfiguredObjectFactory configuredFactory, IMemberMapperData mapperData)
+            {
+                _configuredFactory = configuredFactory;
+                _mapperData = mapperData;
+                IsConfigured = true;
+                IsUnconditional = !_configuredFactory.HasConfiguredCondition;
+            }
+
+            public override Construction ToConstruction() => new Construction(_configuredFactory, _mapperData);
+        }
+
+        private sealed class ConstructionDataInfo<TInvokable> : ConstructionInfoBase
             where TInvokable : MethodBase
         {
-            private readonly Tuple<QualifiedMember, DataSourceSet>[] _argumentDataSources;
+            private readonly TInvokable _invokable;
+            private readonly Func<TInvokable, IList<Expression>, Expression> _constructionFactory;
 
-            public ConstructionData(
+            public ConstructionDataInfo(
                 TInvokable invokable,
                 Func<TInvokable, IList<Expression>, Expression> constructionFactory,
                 ConstructionKey key,
                 int priority)
             {
-                var argumentDataSources = GetArgumentDataSources(invokable, key);
+                _invokable = invokable;
+                _constructionFactory = constructionFactory;
 
-                CanBeInvoked = argumentDataSources.All(ds => ds.Item2.HasValue);
-                ParameterCount = argumentDataSources.Length;
+                ArgumentDataSources = GetArgumentDataSources(invokable, key);
+                CanBeInvoked = ArgumentDataSources.All(ds => ds.HasValue);
+                ParameterCount = ArgumentDataSources.Length;
                 Priority = priority;
 
                 if (!CanBeInvoked)
@@ -262,27 +364,84 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                     return;
                 }
 
-                IsUnconditional = true;
+                IsUnconditional = !ArgumentDataSources.Any(ds => ds.MapperData.TargetMember.IsComplex && ds.IsConditional);
+            }
 
+            private static DataSourceSet[] GetArgumentDataSources(TInvokable invokable, ConstructionKey key)
+            {
+                return invokable
+                    .GetParameters()
+                    .ProjectToArray(p =>
+                    {
+                        var parameterMapperData = new ChildMemberMapperData(
+                            key.MappingData.MapperData.TargetMember.Append(Member.ConstructorParameter(p)),
+                            key.MappingData.MapperData);
+
+                        var memberMappingData = key.MappingData.GetChildMappingData(parameterMapperData);
+                        var dataSources = DataSourceFinder.FindFor(memberMappingData);
+
+                        return dataSources;
+                    });
+            }
+
+            public DataSourceSet[] ArgumentDataSources { get; }
+
+            public bool CanBeInvoked { get; }
+
+            public void AddTo(IList<IConstructionInfo> constructionInfos, ConstructionKey key)
+            {
+                if (ParameterCount > 0)
+                {
+                    var dataSources = key.MappingData.MapperData.DataSourcesByTargetMember;
+
+                    foreach (var dataSourceSet in ArgumentDataSources.Filter(ds => !dataSources.ContainsKey(ds.MapperData.TargetMember)))
+                    {
+                        dataSources.Add(dataSourceSet.MapperData.TargetMember, dataSourceSet);
+                    }
+                }
+
+                constructionInfos.AddSorted(this);
+            }
+
+            public Expression GetConstructionExpression(IList<Expression> argumentValues)
+                => _constructionFactory.Invoke(_invokable, argumentValues);
+
+            public override Construction ToConstruction() => new ConstructionData<TInvokable>(this).Construction;
+        }
+
+        private sealed class StructInfo : ConstructionInfoBase
+        {
+            private readonly Type _targetType;
+
+            public StructInfo(Type targetType)
+            {
+                _targetType = targetType;
+                IsUnconditional = true;
+            }
+
+            public override Construction ToConstruction() => new Construction(Expression.New(_targetType));
+        }
+
+        private sealed class ConstructionData<TInvokable>
+            where TInvokable : MethodBase
+        {
+            public ConstructionData(ConstructionDataInfo<TInvokable> info)
+            {
                 Expression constructionExpression;
 
-                if (argumentDataSources.None())
+                if (info.ArgumentDataSources.None())
                 {
-                    constructionExpression = constructionFactory.Invoke(invokable, Enumerable<Expression>.EmptyArray);
-                    Construction = new Construction(this, constructionExpression);
+                    constructionExpression = info.GetConstructionExpression(Enumerable<Expression>.EmptyArray);
+                    Construction = new Construction(constructionExpression);
                     return;
                 }
 
-                _argumentDataSources = argumentDataSources;
-
                 var variables = default(List<ParameterExpression>);
-                var argumentValues = new List<Expression>(ParameterCount);
+                var argumentValues = new List<Expression>(info.ParameterCount);
                 var condition = default(Expression);
 
-                foreach (var argumentDataSource in argumentDataSources)
+                foreach (var dataSources in info.ArgumentDataSources)
                 {
-                    var dataSources = argumentDataSource.Item2;
-
                     if (dataSources.Variables.Any())
                     {
                         if (variables == null)
@@ -297,12 +456,10 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 
                     argumentValues.Add(dataSources.ValueExpression);
 
-                    if (!argumentDataSource.Item1.IsComplex || !dataSources.IsConditional)
+                    if (info.IsUnconditional)
                     {
                         continue;
                     }
-
-                    IsUnconditional = false;
 
                     var dataSourceCondition = BuildConditions(dataSources);
 
@@ -315,28 +472,11 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                     condition = Expression.AndAlso(condition, dataSourceCondition);
                 }
 
-                constructionExpression = constructionFactory.Invoke(invokable, argumentValues);
+                constructionExpression = info.GetConstructionExpression(argumentValues);
 
                 Construction = variables.NoneOrNull()
-                    ? new Construction(this, constructionExpression, condition)
-                    : new Construction(this, Expression.Block(variables, constructionExpression), condition);
-            }
-
-            private static Tuple<QualifiedMember, DataSourceSet>[] GetArgumentDataSources(TInvokable invokable, ConstructionKey key)
-            {
-                return invokable
-                    .GetParameters()
-                    .ProjectToArray(p =>
-                    {
-                        var parameterMapperData = new ChildMemberMapperData(
-                            key.MappingData.MapperData.TargetMember.Append(Member.ConstructorParameter(p)),
-                            key.MappingData.MapperData);
-
-                        var memberMappingData = key.MappingData.GetChildMappingData(parameterMapperData);
-                        var dataSources = DataSourceFinder.FindFor(memberMappingData);
-
-                        return Tuple.Create(memberMappingData.MapperData.TargetMember, dataSources);
-                    });
+                    ? new Construction(constructionExpression, condition)
+                    : new Construction(Expression.Block(variables, constructionExpression), condition);
             }
 
             private static Expression BuildConditions(DataSourceSet dataSources)
@@ -357,57 +497,18 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 return conditions;
             }
 
-            public bool CanBeInvoked { get; }
-
-            public bool IsUnconditional { get; }
-
-            public int ParameterCount { get; }
-
-            public int Priority { get; }
-
             public Construction Construction { get; }
-
-            public void AddTo(IList<Construction> constructions, ConstructionKey key)
-            {
-                if (ParameterCount > 0)
-                {
-                    var dataSources = key.MappingData.MapperData.DataSourcesByTargetMember;
-
-                    foreach (var memberAndDataSourceSet in _argumentDataSources.Filter(ads => !dataSources.ContainsKey(ads.Item1)))
-                    {
-                        dataSources.Add(memberAndDataSourceSet.Item1, memberAndDataSourceSet.Item2);
-                    }
-                }
-
-                constructions.AddSorted(Construction);
-            }
         }
 
-        private interface IConstructionInfo
-        {
-            int ParameterCount { get; }
-
-            int Priority { get; }
-        }
-
-        private class Construction : IConditionallyChainable, IComparable<Construction>
+        private class Construction : IConditionallyChainable
         {
             private readonly Expression _construction;
-            private readonly bool _isConfigured;
-            private readonly IConstructionInfo _info;
             private ParameterExpression _mappingDataObject;
 
             public Construction(ConfiguredObjectFactory configuredFactory, IMemberMapperData mapperData)
                 : this(configuredFactory.Create(mapperData), configuredFactory.GetConditionOrNull(mapperData))
             {
                 UsesMappingDataObjectParameter = configuredFactory.UsesMappingDataObjectParameter;
-                _isConfigured = true;
-            }
-
-            public Construction(IConstructionInfo info, Expression construction, Expression condition = null)
-                : this(construction, condition)
-            {
-                _info = info;
             }
 
             private Construction(IList<Construction> constructions)
@@ -416,20 +517,13 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 UsesMappingDataObjectParameter = constructions.Any(c => c.UsesMappingDataObjectParameter);
             }
 
-            private Construction(Expression construction, Expression condition = null)
+            public Construction(Expression construction, Expression condition = null)
             {
                 _construction = construction;
                 Condition = condition;
             }
 
             #region Factory Methods
-
-            public static Construction NewStruct(Type type)
-            {
-                var parameterlessNew = Expression.New(type);
-
-                return new Construction(parameterlessNew);
-            }
 
             public static Construction For(IList<Construction> constructions, ConstructionKey key)
             {
@@ -450,8 +544,6 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 
             public Expression PreCondition => null;
 
-            public bool IsUnconditional => Condition == null;
-
             public Expression Condition { get; }
 
             Expression IConditionallyChainable.Value => _construction;
@@ -460,35 +552,6 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 
             public Expression GetConstruction(IObjectMappingData mappingData)
                 => _construction.Replace(_mappingDataObject, mappingData.MapperData.MappingDataObject);
-
-            public int CompareTo(Construction other)
-            {
-                // ReSharper disable once ImpureMethodCallOnReadonlyValueField
-                var isConfiguredComparison = other._isConfigured.CompareTo(_isConfigured);
-
-                if (isConfiguredComparison != 0)
-                {
-                    return isConfiguredComparison;
-                }
-
-                var conditionalComparison = IsUnconditional.CompareTo(other.IsUnconditional);
-
-                if (conditionalComparison != 0)
-                {
-                    return conditionalComparison;
-                }
-
-                var paramCountComparison = _info.ParameterCount.CompareTo(other._info.ParameterCount);
-
-                if (paramCountComparison != 0)
-                {
-                    return paramCountComparison;
-                }
-
-                var priorityComparison = other._info.Priority.CompareTo(_info.Priority);
-
-                return priorityComparison;
-            }
         }
 
         #endregion

--- a/AgileMapper/ObjectPopulation/ComplexTypes/IBasicConstructionInfo.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/IBasicConstructionInfo.cs
@@ -1,13 +1,17 @@
 namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 {
+    using Members;
+
     internal interface IBasicConstructionInfo
     {
         bool IsConfigured { get; }
-            
+
         bool IsUnconditional { get; }
-            
+
         int ParameterCount { get; }
-            
+
         int Priority { get; }
+
+        bool HasCtorParameterFor(Member targetMember);
     }
 }

--- a/AgileMapper/ObjectPopulation/ComplexTypes/IBasicConstructionInfo.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/IBasicConstructionInfo.cs
@@ -1,0 +1,13 @@
+namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
+{
+    internal interface IBasicConstructionInfo
+    {
+        bool IsConfigured { get; }
+            
+        bool IsUnconditional { get; }
+            
+        int ParameterCount { get; }
+            
+        int Priority { get; }
+    }
+}

--- a/AgileMapper/ObjectPopulation/ComplexTypes/MemberInitPopulationExpressionFactory.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/MemberInitPopulationExpressionFactory.cs
@@ -1,13 +1,13 @@
 namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 {
     using System.Collections.Generic;
-    using Extensions.Internal;
-    using Members.Population;
 #if NET35
     using Microsoft.Scripting.Ast;
 #else
     using System.Linq.Expressions;
 #endif
+    using Extensions.Internal;
+    using Members.Population;
 
     internal class MemberInitPopulationExpressionFactory : PopulationExpressionFactoryBase
     {
@@ -18,9 +18,9 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             yield return memberPopulator.GetPopulation();
         }
 
-        protected override Expression GetNewObjectCreation(IObjectMappingData mappingData, IList<Expression> memberPopulations)
+        protected override Expression GetTargetObjectCreation(IObjectMappingData mappingData, IList<Expression> memberPopulations)
         {
-            var objectCreation = base.GetNewObjectCreation(mappingData, memberPopulations);
+            var objectCreation = base.GetTargetObjectCreation(mappingData, memberPopulations);
 
             if (objectCreation == null)
             {

--- a/AgileMapper/ObjectPopulation/ComplexTypes/PopulationExpressionFactoryBase.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/PopulationExpressionFactoryBase.cs
@@ -104,7 +104,11 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             IObjectMappingData mappingData,
             IList<Expression> memberPopulations)
         {
-            return mappingData.GetTargetObjectCreation();
+            return mappingData
+                .MapperData
+                .MapperContext
+                .ConstructionFactory
+                .GetNewObjectCreation(mappingData);
         }
 
         #region Object Registration

--- a/AgileMapper/ObjectPopulation/ComplexTypes/PopulationExpressionFactoryBase.cs
+++ b/AgileMapper/ObjectPopulation/ComplexTypes/PopulationExpressionFactoryBase.cs
@@ -2,15 +2,15 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
 {
     using System.Collections.Generic;
     using System.Linq;
-    using Extensions.Internal;
-    using Members;
-    using Members.Population;
-    using NetStandardPolyfills;
 #if NET35
     using Microsoft.Scripting.Ast;
 #else
     using System.Linq.Expressions;
 #endif
+    using Extensions.Internal;
+    using Members;
+    using Members.Population;
+    using NetStandardPolyfills;
     using static CallbackPosition;
 
     internal abstract class PopulationExpressionFactoryBase
@@ -92,7 +92,7 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             IObjectMappingData mappingData)
         {
             var localVariableValue = TargetObjectResolutionFactory.GetObjectResolution(
-                GetNewObjectCreation,
+                GetTargetObjectCreation,
                 mappingData,
                 memberPopulations,
                 assignCreatedObject);
@@ -100,7 +100,7 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
             return mappingData.MapperData.LocalVariable.AssignTo(localVariableValue);
         }
 
-        protected virtual Expression GetNewObjectCreation(
+        protected virtual Expression GetTargetObjectCreation(
             IObjectMappingData mappingData,
             IList<Expression> memberPopulations)
         {
@@ -108,7 +108,7 @@ namespace AgileObjects.AgileMapper.ObjectPopulation.ComplexTypes
                 .MapperData
                 .MapperContext
                 .ConstructionFactory
-                .GetNewObjectCreation(mappingData);
+                .GetTargetObjectCreation(mappingData);
         }
 
         #region Object Registration

--- a/AgileMapper/ObjectPopulation/ObjectMapper.cs
+++ b/AgileMapper/ObjectPopulation/ObjectMapper.cs
@@ -3,15 +3,15 @@ namespace AgileObjects.AgileMapper.ObjectPopulation
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Caching;
-    using MapperKeys;
-    using NetStandardPolyfills;
-    using RepeatedMappings;
 #if NET35
     using Microsoft.Scripting.Ast;
 #else
     using System.Linq.Expressions;
 #endif
+    using Caching;
+    using MapperKeys;
+    using NetStandardPolyfills;
+    using RepeatedMappings;
 
     internal class ObjectMapper<TSource, TTarget> : IObjectMapper
     {

--- a/AgileMapper/ObjectPopulation/ObjectMapperData.cs
+++ b/AgileMapper/ObjectPopulation/ObjectMapperData.cs
@@ -668,7 +668,7 @@ namespace AgileObjects.AgileMapper.ObjectPopulation
             MethodInfo mapRepeatedMethod;
             Expression[] arguments;
 
-            if (targetMember.LeafMember.IsEnumerableElement())
+            if (targetMember.IsEnumerableElement())
             {
                 mapRepeatedMethod = _mapRepeatedElementMethod;
 

--- a/AgileMapper/Validation/MappingValidator.cs
+++ b/AgileMapper/Validation/MappingValidator.cs
@@ -82,7 +82,7 @@
                     IsUnmappable =
                         !md.IsRoot &&
                          md.TargetMember.IsComplex &&
-                         md.DataSourcesByTargetMember.None(),
+                         md.DataSourcesByTargetMember.None(ds => ds.Value.HasValue),
                     UnmappedMembers = md
                         .DataSourcesByTargetMember
                         .Filter(pair => !pair.Value.HasValue)
@@ -98,7 +98,7 @@
                     UnmappableTargetTypes = g
                         .Filter(d => d.IsUnmappable)
                         .Project(d => d.MapperData)
-                        .ToList(),
+                        .ToArray(),
                     UnmappedMembers = g
                         .SelectMany(d => d.UnmappedMembers)
                         .ToDictionary(kvp => kvp.Key, kvp => kvp.Value),


### PR DESCRIPTION
- Populating members with a matching constructor parameter that might not be used, re: #139 
- Using single-data-source population conditions for readonly member populations
- Improving mapping validation detection of unconstructable members
- Performance improvements