### PR TITLE
Fixing mapping plan translation with assignments of local enum variables

### DIFF
--- a/AgileMapper/DataSources/DataSourceBase.cs
+++ b/AgileMapper/DataSources/DataSourceBase.cs
@@ -74,15 +74,16 @@
                 return;
             }
 
-            var numberOfInvocations = valueInfo.MultiInvocations.Count;
-            variables = new ParameterExpression[numberOfInvocations];
-            var cacheVariablesByValue = new Dictionary<Expression, Expression>(numberOfInvocations);
-            var valueExpressions = new Expression[numberOfInvocations + 1];
+            // TODO: Optimise for single multi-invocation
+            var multiInvocationsCount = valueInfo.MultiInvocations.Count;
+            variables = new ParameterExpression[multiInvocationsCount];
+            var cacheVariablesByValue = new Dictionary<Expression, Expression>(multiInvocationsCount);
+            var valueExpressions = new Expression[multiInvocationsCount + 1];
 
-            for (var i = 0; i < numberOfInvocations; i++)
+            for (var i = 0; i < multiInvocationsCount; i++)
             {
                 var invocation = valueInfo.MultiInvocations[i];
-                var valueVariableName = invocation.Type.GetFriendlyName().ToCamelCase() + "Value";
+                var valueVariableName = invocation.Type.GetVariableNameInCamelCase() + "Value";
                 var valueVariable = Expression.Variable(invocation.Type, valueVariableName);
                 var valueVariableValue = invocation.Replace(cacheVariablesByValue);
 
@@ -91,7 +92,7 @@
                 valueExpressions[i] = valueVariable.AssignTo(valueVariableValue);
             }
 
-            valueExpressions[numberOfInvocations] = value.Replace(cacheVariablesByValue);
+            valueExpressions[multiInvocationsCount] = value.Replace(cacheVariablesByValue);
             value = Expression.Block(valueExpressions);
         }
 

--- a/AgileMapper/Validation/EnumMappingMismatchFinder.cs
+++ b/AgileMapper/Validation/EnumMappingMismatchFinder.cs
@@ -149,6 +149,7 @@
         protected override Expression VisitBinary(BinaryExpression binary)
         {
             if ((binary.NodeType == ExpressionType.Assign) &&
+                (binary.Left.NodeType != ExpressionType.Parameter) &&
                  IsEnum(binary.Left.Type) &&
                  TryGetMatch(binary.Left, out var targetMemberData))
             {


### PR DESCRIPTION
Fixing mapping plan translation with assignments of local enum variables, re: #168

Using GetVariableNameInCamelCase() for multi-invocation local variables